### PR TITLE
Require RIVULET_RUN_ID for cross-job thread grouping

### DIFF
--- a/cmd/publish/main.go
+++ b/cmd/publish/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
-	"github.com/google/uuid"
 	"github.com/mr-joshcrane/rivulet"
 )
 
@@ -30,7 +29,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	state := loadOrCreateState(name)
+	runID := os.Getenv("RIVULET_RUN_ID")
+	if runID == "" {
+		fmt.Fprintln(os.Stderr, "RIVULET_RUN_ID must be set")
+		os.Exit(1)
+	}
+
+	state := loadOrCreateState(name, runID)
 	state.Order++
 	saveState(name, state)
 
@@ -93,15 +98,16 @@ func statePath(name string) string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("rivulet-%s.json", name))
 }
 
-func loadOrCreateState(name string) runState {
+func loadOrCreateState(name, runID string) runState {
 	data, err := os.ReadFile(statePath(name))
 	if err != nil {
-		return runState{ID: uuid.New().String(), Order: 0}
+		return runState{ID: runID, Order: 0}
 	}
 	var state runState
 	if json.Unmarshal(data, &state) != nil {
-		return runState{ID: uuid.New().String(), Order: 0}
+		return runState{ID: runID, Order: 0}
 	}
+	state.ID = runID
 	return state
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.30.4
 	github.com/google/go-cmp v0.6.0
-	github.com/google/uuid v1.6.0
 	github.com/mr-joshcrane/glambda v0.0.0-20240505061857-2b3504bf00f4
 )
 
@@ -32,5 +31,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )


### PR DESCRIPTION
## Summary

The publish CLI now requires `RIVULET_RUN_ID` to be set. This lets callers provide a shared identifier (e.g. git commit SHA) across separate CI jobs so all messages land in the same Slack thread.

No more auto-generated UUIDs — the caller controls thread identity. Removes the `uuid` dependency.

## Usage

```bash
export RIVULET_RUN_ID=$(git rev-parse --short HEAD)
export RIVULET_NAME="snak"
publish "🚀 Build starting..."
# later, in a different job with the same RIVULET_RUN_ID:
publish "✅ Deploy complete!"
```